### PR TITLE
Add optional `--static-php-version` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This **experimental** add-on tries to address that need, although there are a nu
 1. `ddev get rfay/ddev-php-patch-build`
 2. `ddev restart`
 
-Using DDEV v1.23.5+, you can select a different PHP version with:
+With DDEV v1.23.5+ you can choose a different PHP version, the command below creates a `.ddev/.env.php-patch-build` file that you can commit:
 
-1. `ddev get rfay/ddev-php-patch-build --environment="STATIC_PHP_VERSION=8.0.10"`
+1. `ddev add-on get rfay/ddev-php-patch-build --static-php-version=8.0.10`
 2. `ddev restart`
 
 ## Components of the add-on

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This **experimental** add-on tries to address that need, although there are a nu
 
 With DDEV v1.23.5+ you can choose a different PHP version, the command below creates a `.ddev/.env.php-patch-build` file that you can commit:
 
-1. `ddev add-on get rfay/ddev-php-patch-build --static-php-version=8.0.10`
+1. `ddev dotenv set .ddev/.env.php-patch-build --static-php-version=8.0.10`
+1. `ddev add-on get rfay/ddev-php-patch-build`
 2. `ddev restart`
 
 ## Components of the add-on

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ This **experimental** add-on tries to address that need, although there are a nu
 ## Installation
 
 1. `ddev get rfay/ddev-php-patch-build`
+2. `ddev restart`
 
+Using DDEV v1.23.4+, you can select a different PHP version with:
+
+1. `ddev get rfay/ddev-php-patch-build --environment="STATIC_PHP_VERSION=8.0.10"`
+2. `ddev restart`
 
 ## Components of the add-on
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This **experimental** add-on tries to address that need, although there are a nu
 1. `ddev get rfay/ddev-php-patch-build`
 2. `ddev restart`
 
-Using DDEV v1.23.4+, you can select a different PHP version with:
+Using DDEV v1.23.5+, you can select a different PHP version with:
 
 1. `ddev get rfay/ddev-php-patch-build --environment="STATIC_PHP_VERSION=8.0.10"`
 2. `ddev restart`

--- a/install.yaml
+++ b/install.yaml
@@ -8,14 +8,19 @@ project_files:
 post_install_actions:
   - |
     #ddev-nodisplay
-    printf "\n\nPlease enter the PHP patch version you want to use, like 7.4.23 or 8.0.10: "
+    if [ "${STATIC_PHP_VERSION:-}" = "" ]; then
+      printf "\n\nPlease enter the PHP patch version you want to use, like 7.4.23 or 8.0.10: "
+    fi
 
   - |
     #ddev-nodisplay
     #ddev-description:Set PHP patch version
-    read static_php_version
-    echo "STATIC_PHP_VERSION=${static_php_version}"
-    echo "ENV STATIC_PHP_VERSION=${static_php_version}" > web-build/pre.Dockerfile.php-patch-build
+    if [ "${STATIC_PHP_VERSION:-}" = "" ]; then
+      read STATIC_PHP_VERSION
+      echo "STATIC_PHP_VERSION=\"${STATIC_PHP_VERSION}\"" > .env.php-patch-build
+    fi
+    echo "STATIC_PHP_VERSION=${STATIC_PHP_VERSION}"
+    echo "ENV STATIC_PHP_VERSION=${STATIC_PHP_VERSION}" > web-build/pre.Dockerfile.php-patch-build
 
 removal_actions:
   - rm -f ${DDEV_APPROOT}/.ddev/web-build/pre.Dockerfile.php-patch-build

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,7 +14,7 @@ setup() {
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --fail-on-hook-fail
   ddev start -y
-  export STATIC_PHP_VERSION="8.2.8"
+  export CUSTOM_PHP_MINOR_VERSION="8.2.8"
   cat <<EOF >index.php
 <?php
 echo phpversion();
@@ -24,10 +24,10 @@ EOF
 health_checks() {
   run ddev php --version
   assert_success
-  assert_output --partial "PHP ${STATIC_PHP_VERSION}"
+  assert_output --partial "PHP ${CUSTOM_PHP_MINOR_VERSION}"
   run curl --fail -s https://${PROJNAME}.ddev.site/
   assert_success
-  assert_output --partial "${STATIC_PHP_VERSION}"
+  assert_output --partial "${CUSTOM_PHP_MINOR_VERSION}"
 }
 
 teardown() {
@@ -40,8 +40,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  echo ${STATIC_PHP_VERSION} | ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR} --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
   ddev restart >/dev/null
   health_checks
 }
@@ -49,8 +49,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-php-patch-build with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  echo ${STATIC_PHP_VERSION} | ddev get ${DIR}
+  echo "# ddev add-on get ddev/ddev-php-patch-build with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR} --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
   ddev restart >/dev/null
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -47,6 +47,7 @@ teardown() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
@@ -56,4 +57,3 @@ teardown() {
   ddev restart >/dev/null
   health_checks
 }
-

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -41,7 +41,8 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev add-on get ${DIR} --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
+  ddev dotenv set .ddev/.env.php-patch-build --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
+  ddev add-on get ${DIR}
   ddev restart >/dev/null
   health_checks
 }
@@ -50,7 +51,8 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev add-on get ddev/ddev-php-patch-build with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev add-on get ${DIR} --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
+  ddev dotenv set .ddev/.env.php-patch-build --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
+  ddev add-on get ${DIR}
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/4430

## How This PR Solves The Issue

Adds optional `--static-php-version value` flag, that creates `.ddev/.env.php-patch-build` file with `STATIC_PHP_VERSION="value"`.

## Manual Testing Instructions

Install add-on using DDEV binary from:

- https://github.com/ddev/ddev/pull/6406

```
ddev dotenv set .ddev/.env.php-patch-build --static-php-version=8.0.10
ddev add-on get https://github.com/stasadev/ddev-php-patch-build/tarball/20240717_stasadev_optional_version
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

