### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,23 @@ This **experimental** add-on tries to address that need, although there are a nu
 
 ## Installation
 
-1. `ddev get rfay/ddev-php-patch-build`
-2. `ddev restart`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get rfay/ddev-php-patch-build
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get rfay/ddev-php-patch-build
+```
+
+Then restart your project
+
+```sh
+ddev restart
+```
 
 With DDEV v1.23.5+ you can choose a different PHP version, the command below creates a `.ddev/.env.php-patch-build` file that you can commit:
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.