### PR TITLE
fix: remove settings php to php8.2

### DIFF
--- a/web-build/Dockerfile.php-patch-build
+++ b/web-build/Dockerfile.php-patch-build
@@ -2,7 +2,6 @@
 ENV EXTENSIONS=bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl,phar,pdo,pdo_mysql,xml,gd,openssl,mbstring,apcu,fileinfo,session,filter,ctype,dom,simplexml
 RUN apt update && apt install -y build-essential
 RUN mkdir -p /usr/local/src/static-php-cli && chown -R ${uid}:${gid} /usr/local/src
-RUN update-alternatives --set php /usr/bin/php8.2
 USER ${uid}:${gid}
 RUN git clone https://github.com/crazywhalecc/static-php-cli.git /usr/local/src/static-php-cli/.
 WORKDIR /usr/local/src/static-php-cli


### PR DESCRIPTION
Oddly, we were explicitly setting the PHP version to 8.2. I assume maybe this add-on was created when 8.1 was stable and we needed 8.2. Now 8.3+ is required by static-php-cli, and DDEV's default is 8.3, so best to just remove that.