### PR TITLE
Use php8.4 for build, now required

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ ddev restart
 You can choose a different PHP version, the command below creates a `.ddev/.env.php-patch-build` file that you can commit:
 
 1. `ddev dotenv set .ddev/.env.php-patch-build --static-php-version=8.0.10`
-1. `ddev add-on get rfay/ddev-php-patch-build`
-2. `ddev restart`
+2. `ddev add-on get rfay/ddev-php-patch-build`
+3. `ddev restart`
 
 ## Components of the add-on
 

--- a/config.php-patch-build.yaml
+++ b/config.php-patch-build.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 webimage_extra_packages: [build-essential]
-# static-php-cli requires at least php 8.4 to build, but the resultant php binary will be as set in
-#
+# static-php-cli requires at least php 8.4 to build, but the resultant static php binary will be as set in
+# ddev dotenv set .ddev/.env.php-patch-build --static-php-version=<whatever>
 php_version: 8.4
 hooks:
   post-start:

--- a/config.php-patch-build.yaml
+++ b/config.php-patch-build.yaml
@@ -1,5 +1,8 @@
 #ddev-generated
 webimage_extra_packages: [build-essential]
+# static-php-cli requires at least php 8.4 to build, but the resultant php binary will be as set in
+#
+php_version: 8.4
 hooks:
   post-start:
     - exec: "sudo ln -sf /usr/local/src/static-php-cli/buildroot/bin/php /usr/bin/php"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -12,7 +12,7 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME} --fail-on-hook-fail
+  ddev config --project-name=${PROJNAME} --fail-on-hook-fail --php-version=8.4
   ddev start -y
   export CUSTOM_PHP_MINOR_VERSION="8.4.1"
   cat <<EOF >index.php

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,7 +14,8 @@ setup() {
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME} --fail-on-hook-fail --php-version=8.4
   ddev start -y
-  export CUSTOM_PHP_MINOR_VERSION="8.4.1"
+  ddev describe
+  export CUSTOM_PHP_MINOR_VERSION="8.2.23"
   cat <<EOF >index.php
 <?php
 echo phpversion();
@@ -43,7 +44,7 @@ teardown() {
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev dotenv set .ddev/.env.php-patch-build --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
   ddev add-on get ${DIR}
-  ddev restart >/dev/null
+  ddev restart -y >/dev/null
   health_checks
 }
 
@@ -54,6 +55,6 @@ teardown() {
   echo "# ddev add-on get ddev/ddev-php-patch-build with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev dotenv set .ddev/.env.php-patch-build --static-php-version="${CUSTOM_PHP_MINOR_VERSION}"
   ddev add-on get ${DIR}
-  ddev restart >/dev/null
+  ddev restart -y >/dev/null
   health_checks
 }


### PR DESCRIPTION
Recent versions of https://github.com/crazywhalecc/static-php-cli seem to work only with PHP 8.4. I'm not sure the full implications of this.