### PR TITLE
fix: handle DDEV HEAD changes to php-fpm alternatives and GitHub API rate limiting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: ddev/github-action-add-on-test@v2
         with:

--- a/web-build/Dockerfile.php-patch-build
+++ b/web-build/Dockerfile.php-patch-build
@@ -10,7 +10,7 @@ set -eu -o pipefail
 
 # static-php-cli requires at least PHP 8.4 to build
 update-alternatives --set php /usr/bin/php8.4
-ln -sf /usr/sbin/php-fpm8.4 /usr/sbin/php-fpm
+if update-alternatives --display php-fpm >/dev/null 2>&1; then update-alternatives --set php-fpm /usr/sbin/php-fpm8.4; else ln -sf /usr/sbin/php-fpm8.4 /usr/sbin/php-fpm; fi
 
 mkdir -p /usr/local/src/static-php-cli && cd /usr/local/src/static-php-cli
 git clone https://github.com/crazywhalecc/static-php-cli.git .


### PR DESCRIPTION
## The Issue

Tests against DDEV HEAD are failing due to two issues introduced by ddev/ddev#8195 (commit b07a32a):

1. **GitHub API rate limiting** — `static-php-cli`'s `spc download` fetches release metadata from `api.github.com`. Without an authenticated token, Docker layer cache misses (which happen more often against HEAD due to a new base image) trigger unauthenticated requests that hit the rate limit (HTTP 403).

2. **Broken php-fpm symlink** — ddev/ddev#8195 stopped making `/usr/sbin` world-writable and switched `/usr/sbin/php-fpm` to be managed via `update-alternatives` (registered during the base image build). The Dockerfile was using `ln -sf /usr/sbin/php-fpm8.4 /usr/sbin/php-fpm` which overwrites the alternatives-managed symlink with a direct one. At container startup, `start.sh` then calls `update-alternatives --set php-fpm`, which needs to restore `/usr/sbin/php-fpm` → `/etc/alternatives/php-fpm` — but `/usr/sbin` is no longer world-writable, so it fails as non-root.

## How This PR Solves The Issues

**Rate limiting** (`.github/workflows/tests.yml`): Export `GITHUB_TOKEN` as a job-level env var so the Docker build arg `${GITHUB_TOKEN:-}` in `docker-compose.php-patch-build.yaml` resolves to an authenticated token. Also adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` as required by current GitHub Actions.

**php-fpm symlink** (`web-build/Dockerfile.php-patch-build`): Replace the unconditional `ln -sf /usr/sbin/php-fpm8.4 /usr/sbin/php-fpm` with a conditional:
- If the `php-fpm` alternatives group exists (DDEV HEAD): use `update-alternatives --set`, preserving the managed symlink chain so `start.sh` can switch it at runtime without needing write access to `/usr/sbin`
- Otherwise (DDEV stable v1.25.1 and earlier, where no alternatives group exists): fall back to the original `ln -sf`

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/rfay/ddev-php-patch-build/tarball/refs/pull/11/head
ddev restart
```

## Automated Testing Overview

The existing CI matrix tests both `stable` and `HEAD` DDEV versions.
